### PR TITLE
fix clearInputOnSelectChoice behaviour

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -109,15 +109,17 @@ yourlabs.Widget.prototype.selectChoice = function(choice) {
     var index = $(':input:visible').index(this.input);
     this.resetDisplay();
 
+    if (this.clearInputOnSelectChoice === '1') {
+        this.input.val('');
+        this.autocomplete.value = '';
+    }
+
     if (this.input.is(':visible')) {
         this.input.focus();
     } else {
         var next = $(':input:visible:eq('+ index +')');
         next.focus();
     }
-
-    if (this.clearInputOnSelectChoice === '1')
-        this.input.val('');
 }
 
 // Unselect a value if the maximum number of selected values has been


### PR DESCRIPTION
this fixes two different issues
- by clearing autocomplete.value as well as input.val we make sure that
  subsequent clicks will not open the autocomplete filtered by a value
  that is no longer visible to the user
- by clearing the input before triggering the focus we make sure the
  minimumCharacters settings is honored

I've not built the files in dist/\* because there seem to be other changes in master 
right now that have not been built either and it made the changes look confusing.
