### PR TITLE
Remove array indexOf(), which breaks IE8

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -295,7 +295,8 @@ yourlabs.Autocomplete = function (input) {
     <body>.
     */
     this.container = this.input.parents().filter(function() {
-        return ['absolute', 'fixed'].indexOf($(this).css('position')) > -1;
+        var position = $(this).css('position');
+        return position === 'absolute' || position === 'fixed';
     }).first();
     if (!this.container.length) this.container = $('body');
 };


### PR DESCRIPTION
As far as I can tell, this is the only bit of the code that breaks in IE8. Seems to work fine now with this fix.
