### PR TITLE
Fixes bad positioning

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -579,17 +579,33 @@ the system from Django admin's JS widgets like the date calendar, which means:
 - 
 */
 yourlabs.Autocomplete.prototype.fixPosition = function() {
-    var el = this.input.get(0)
+    var el = this.input.get(0);
 
     var zIndex = this.input.parents().filter(function() {
         return $(this).css('z-index') !== 'auto' && $(this).css('z-index') !== '0';
     }).first().css('z-index');
 
+    var absolute_parent = this.input.parents().filter(function(){
+      return $(this).css('position') === 'absolute';
+    }).get(0);
+
+    var top = (findPosY(el) + this.input.outerHeight()) + 'px';
+    var left = findPosX(el) + 'px';
+
+    if(absolute_parent !== undefined){
+        var parentTop = findPosY(absolute_parent);
+        var parentLeft = findPosX(absolute_parent);
+        var inputBottom = findPosY(el) + this.input.outerHeight();
+        var inputLeft = findPosX(el);
+        top = (inputBottom - parentTop) + 'px';
+        left = (inputLeft - parentLeft) + 'px';
+    }
+
     this.box.appendTo(this.container).css({
         position: 'absolute',
         minWidth: parseInt(this.input.outerWidth()),
-        top: (findPosY(el) + this.input.outerHeight()) + 'px',
-        left: findPosX(el) + 'px',
+        top: top,
+        left: left,
         zIndex: zIndex
     });
 };


### PR DESCRIPTION
As was noticed in issue #7, there was a problem with positioning the choices box when an ancestor of the autocomplete input had a css position different from "static" (the default).

With these changes in fixPosition method in autocomplete.js file the problem seems to be solved. I test it using the same example shown in the issue #7, using django 1.8 admin site and using grappelli over django admin site. They all worked great. I attach some pictures to show how it works.

![admin](https://cloud.githubusercontent.com/assets/1700075/9674222/77373798-5284-11e5-972d-033e39996a6d.png)
![grappelli](https://cloud.githubusercontent.com/assets/1700075/9674221/7732f200-5284-11e5-97b8-875e17256449.png)
![simple_example](https://cloud.githubusercontent.com/assets/1700075/9674223/77380d12-5284-11e5-8d5a-6c3c111e650c.png)
