### PR TITLE
Fixed #535: results open in new tabs

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -250,6 +250,13 @@ yourlabs.Autocomplete = function (input) {
     */
     this.autoHilightFirst = false;
 
+
+    /*
+    You can set this variable to false in order to allow opening of results
+    in new tabs or windows
+    */
+    this.bindMouseDown = true;
+
     /*
     The value of the input is passed to the server via a GET variable. This
     is the name of the variable.
@@ -356,8 +363,11 @@ yourlabs.Autocomplete.prototype.initialize = function() {
      */
     this.box
         .on('mouseenter', this.choiceSelector, $.proxy(this.boxMouseenter, this))
-        .on('mouseleave', this.choiceSelector, $.proxy(this.boxMouseleave, this))
+        .on('mouseleave', this.choiceSelector, $.proxy(this.boxMouseleave, this));
+    if(this.bindMouseDown){
+        this.box
         .on('mousedown', this.choiceSelector, $.proxy(this.boxClick, this));
+    }
 
     /*
     Initially - empty data queried


### PR DESCRIPTION
Added option to disable binding mousedown so that results can be opened in new tabs or windows
