### PR TITLE
Disable the widget input when it is not in use

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -120,6 +120,8 @@ yourlabs.Widget.prototype.selectChoice = function(choice) {
         var next = $(':input:visible:eq('+ index +')');
         next.focus();
     }
+
+    this.input.prop('disabled', true);
 }
 
 // Unselect a value if the maximum number of selected values has been
@@ -235,6 +237,8 @@ yourlabs.Widget.prototype.deselectChoice = function(choice) {
     this.updateAutocompleteExclude();
     this.resetDisplay();
 
+    this.input.prop('disabled', false);
+
     this.widget.trigger('widgetDeselectChoice', [choice, this]);
 };
 
@@ -263,6 +267,10 @@ yourlabs.Widget.prototype.initialize = function() {
 
     this.addRemove(choices);
     this.resetDisplay();
+
+    if (widget.select.val()) {
+        this.input.prop('disabled', true);
+    }
 
     this.bindSelectChoice();
 }


### PR DESCRIPTION
In cases where the input for `Widget` has a `required` attribute, it is impossible to submit the form on browsers like Chrome because it complains that a required field is hidden and has no value (since the default is `clearInputOnSelectChoice`). I don't think there's any real reason to submit the value of that input to the server anyway (especially with the default behavior being it is blank).

This PR disables the input any time it isn't visible, which allows it to be required when visible (and prevent submission to the server if empty) but still work when hidden. I'm not sure added code is in the absolute best spot since I don't know the logic in those functions well enough to know if it should perhaps come earlier or later. In my testing it worked fine on forms both with an initial value from the server and ones that are initially empty.
