### PR TITLE
Straighten out licensing issue.  

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,4 +124,4 @@ Check [CONTRIBUTING.md](https://github.com/yourlabs/jquery-autocomplete-light/bl
 
 ## License
 
-BSD
+MIT


### PR DESCRIPTION
Only README.md shows BSD license, and the only substantial difference between MIT & BSD is the promotional limitation (logos, trademarks, etc cannot be used to promote things built with this).

README.md seems to only date to May 31, 2015, so only a few contributions _might_ have been made with the understanding of a BSD license--as far as I can tell any earlier contributions would have been made under the MIT license.
