### PR TITLE
Fix multiple selections

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -121,7 +121,9 @@ yourlabs.Widget.prototype.selectChoice = function(choice) {
         next.focus();
     }
 
-    this.input.prop('disabled', true);
+    if (this.input[0].className.indexOf('multiplechoicewidget') < 0) {
+        this.input.prop('disabled', true);
+    }
 }
 
 // Unselect a value if the maximum number of selected values has been


### PR DESCRIPTION
The autocomplete widget is currently being disabled after a single value is selected, preventing the option of selecting more values.
This fix does not disable the widget in the case that the input has a class of "multiplechoicewidget".
